### PR TITLE
[DOCS] Fixes shared attributes in eland client

### DIFF
--- a/docs/en/index.asciidoc
+++ b/docs/en/index.asciidoc
@@ -1,4 +1,7 @@
-= eland: pandas-like data analysis toolkit backed by {es}
+= eland: pandas-like data analysis toolkit backed by Elasticsearch
+
+include::{asciidoc-dir}/../../shared/versions/stack/{source_branch}.asciidoc[]
+include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 == Overview
 
@@ -29,6 +32,4 @@ pip install eland
 
 Check https://eland.readthedocs.io/en/latest/[the eland documentation site] for 
 the full documentation and the latest updates.
-
-include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 


### PR DESCRIPTION
In order for shared attributes to be used in the eland client documentation, we must include the appropriate files at the beginning of its index.asciidoc file.  Otherwise, it's not able to resolve those shared attributes.  For example:

![image](https://user-images.githubusercontent.com/26471269/76558748-1a0bbd80-645b-11ea-81f3-e9a70c550a16.png)
